### PR TITLE
temporarily force latest-stable to v3.4 for armhf to fix builds

### DIFF
--- a/armhf-latest-stable/version
+++ b/armhf-latest-stable/version
@@ -1,1 +1,1 @@
-latest-stable
+v3.4


### PR DESCRIPTION
latest-stable (v3.5) build fails for armhf,
I propose to force its version to v3.4 in the meantime,
so builds can pass again. This will be reverted to latest-stable
when the builds work well again.

Not so hacky as todays latest-stable multiarch image for alpine is actually v3.4

What do you think about this ?