### PR TITLE
Add alpine v3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,14 @@ env:
         - ARCH=aarch64  VERSION=v3.7    QEMU_ARCH=aarch64   TAG_ARCH=aarch64
         - ARCH=aarch64  VERSION=v3.7    QEMU_ARCH=aarch64   TAG_ARCH=arm64
 
+        - ARCH=x86      VERSION=v3.8    QEMU_ARCH=i386      TAG_ARCH=x86
+        - ARCH=x86_64   VERSION=v3.8    QEMU_ARCH=x86_64    TAG_ARCH=x86_64
+        - ARCH=x86      VERSION=v3.8    QEMU_ARCH=i386      TAG_ARCH=i386
+        - ARCH=x86_64   VERSION=v3.8    QEMU_ARCH=x86_64    TAG_ARCH=amd64
+        - ARCH=armhf    VERSION=v3.8    QEMU_ARCH=arm       TAG_ARCH=armhf
+        - ARCH=aarch64  VERSION=v3.8    QEMU_ARCH=aarch64   TAG_ARCH=aarch64
+        - ARCH=aarch64  VERSION=v3.8    QEMU_ARCH=aarch64   TAG_ARCH=arm64
+
         - ARCH=x86      VERSION=latest-stable    QEMU_ARCH=i386     TAG_ARCH=x86
         - ARCH=x86_64   VERSION=latest-stable    QEMU_ARCH=x86_64   TAG_ARCH=x86_64
         - ARCH=x86      VERSION=latest-stable    QEMU_ARCH=i386     TAG_ARCH=i386


### PR DESCRIPTION
Adds version 3.8 which was released today.

See: https://alpinelinux.org/posts/Alpine-3.8.0-released.html