### PR TITLE
Add alpine v3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,14 @@ env:
         - ARCH=aarch64  VERSION=v3.8    QEMU_ARCH=aarch64   TAG_ARCH=aarch64
         - ARCH=aarch64  VERSION=v3.8    QEMU_ARCH=aarch64   TAG_ARCH=arm64
 
+        - ARCH=x86      VERSION=v3.9    QEMU_ARCH=i386      TAG_ARCH=x86
+        - ARCH=x86_64   VERSION=v3.9    QEMU_ARCH=x86_64    TAG_ARCH=x86_64
+        - ARCH=x86      VERSION=v3.9    QEMU_ARCH=i386      TAG_ARCH=i386
+        - ARCH=x86_64   VERSION=v3.9    QEMU_ARCH=x86_64    TAG_ARCH=amd64
+        - ARCH=armhf    VERSION=v3.9    QEMU_ARCH=arm       TAG_ARCH=armhf
+        - ARCH=aarch64  VERSION=v3.9    QEMU_ARCH=aarch64   TAG_ARCH=aarch64
+        - ARCH=aarch64  VERSION=v3.9    QEMU_ARCH=aarch64   TAG_ARCH=arm64
+
         - ARCH=x86      VERSION=edge    QEMU_ARCH=i386      TAG_ARCH=x86
         - ARCH=x86_64   VERSION=edge    QEMU_ARCH=x86_64    TAG_ARCH=x86_64
         - ARCH=x86      VERSION=edge    QEMU_ARCH=i386      TAG_ARCH=i386


### PR DESCRIPTION
Adds version 3.9 of Alpine Linux to the build matrix.

Alpine 3.9 was released at 2019-01-29, see: https://alpinelinux.org/posts/Alpine-3.9.0-released.html