### PR TITLE
update.sh: append trailing slash

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -80,7 +80,7 @@ if [ -n "${QEMU_ARCH}" ]; then
     cat >> Dockerfile <<EOF
 
 # Add qemu-user-static binary for amd64 builders
-ADD x86_64_qemu-${QEMU_ARCH}-static.tar.gz /usr/bin
+ADD x86_64_qemu-${QEMU_ARCH}-static.tar.gz /usr/bin/
 EOF
 fi
 


### PR DESCRIPTION
After poking around some of these images I found the .tar.gz file as `/usr/bin`, hopefully this change means `ADD` will extract the contents into `/usr/bin/` instead.