### PR TITLE
Add alpine v3.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
     global:
         - QEMU_VER=v4.0.0
         - DOCKER_REPO=multiarch/alpine
-        - LATEST_VERSION=v3.9
+        - LATEST_VERSION=v3.10
     matrix:
         - ARCH=x86      VERSION=v3.7    QEMU_ARCH=i386      TAG_ARCH=x86
         - ARCH=x86_64   VERSION=v3.7    QEMU_ARCH=x86_64    TAG_ARCH=x86_64
@@ -36,6 +36,14 @@ env:
         - ARCH=armhf    VERSION=v3.9    QEMU_ARCH=arm       TAG_ARCH=armhf
         - ARCH=aarch64  VERSION=v3.9    QEMU_ARCH=aarch64   TAG_ARCH=aarch64
         - ARCH=aarch64  VERSION=v3.9    QEMU_ARCH=aarch64   TAG_ARCH=arm64
+
+        - ARCH=x86      VERSION=v3.10   QEMU_ARCH=i386      TAG_ARCH=x86
+        - ARCH=x86_64   VERSION=v3.10   QEMU_ARCH=x86_64    TAG_ARCH=x86_64
+        - ARCH=x86      VERSION=v3.10   QEMU_ARCH=i386      TAG_ARCH=i386
+        - ARCH=x86_64   VERSION=v3.10   QEMU_ARCH=x86_64    TAG_ARCH=amd64
+        - ARCH=armhf    VERSION=v3.10   QEMU_ARCH=arm       TAG_ARCH=armhf
+        - ARCH=aarch64  VERSION=v3.10   QEMU_ARCH=aarch64   TAG_ARCH=aarch64
+        - ARCH=aarch64  VERSION=v3.10   QEMU_ARCH=aarch64   TAG_ARCH=arm64
 
         - ARCH=x86      VERSION=edge    QEMU_ARCH=i386      TAG_ARCH=x86
         - ARCH=x86_64   VERSION=edge    QEMU_ARCH=x86_64    TAG_ARCH=x86_64


### PR DESCRIPTION
Adds [recently released](https://alpinelinux.org/posts/Alpine-3.10.0-released.html) version 3.10 of Alpine Linux to the build matrix.